### PR TITLE
Fix issue with AdditionalPurchaseData for saplings

### DIFF
--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -440,7 +440,7 @@ namespace JsonAssets
                             PurchaseFrom = entry.PurchaseFrom,
                             Price = entry.PurchasePrice,
                             PurchaseRequirements = entry.PurchaseRequirements == null ? new string[0] : new[] { string.Join("/", entry.PurchaseRequirements?.ToArray()) },
-                            Object = () => new StardewValley.Object(tree.Sapling.Id, 1, true, tree.Sapling.PurchasePrice)
+                            Object = () => new StardewValley.Object(Vector2.Zero, tree.Sapling.Id, int.MaxValue)
                         });
                     }
                 }


### PR DESCRIPTION
The parameters being called when making a new StardewValley.Object in the AdditionalPurchaseData section for saplings resulted in recipes for the sapling being added to the shop so it should be unified with the version of the call made in the regular PurchaseData part several lines above.